### PR TITLE
Add source tracking for emails and phones

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Two environment variables configure the crawler:
 
 - `HIBP_API_KEY` – HaveIBeenPwned API key.
 - `CRAWL_DEPTH` – maximum crawl depth (defaults to `3`).
+- `BREACH_LOG_FILE` – optional path to the log file (defaults to
+  `breach_checker.log`).
 
 When a `config.json` file exists in the repository root it overrides the
 environment variables. The file should contain:
@@ -33,6 +35,7 @@ environment variables. The file should contain:
 ```bash
 export HIBP_API_KEY=YOUR_HIBP_KEY
 # optional: export CRAWL_DEPTH=2
+# optional: export BREACH_LOG_FILE=/path/to/scan.log
 python breach_checker.py
 ```
 Follow the prompts to scan a domain and save results locally. The configuration
@@ -46,6 +49,7 @@ Use Django's built-in server for testing. The server reads `HIBP_API_KEY` and
 ```bash
 export HIBP_API_KEY=YOUR_HIBP_KEY
 # optional: export CRAWL_DEPTH=2
+# optional: export BREACH_LOG_FILE=/path/to/scan.log
 python manage.py runserver
 ```
 
@@ -66,8 +70,22 @@ stack:
 ```bash
 export HIBP_API_KEY=YOUR_HIBP_KEY
 # optional: export CRAWL_DEPTH=2
+# optional: export BREACH_LOG_FILE=/path/to/scan.log
 docker-compose up --build
 ```
 
 The API will be available on `http://localhost:8000/`.
+
+## Output files
+
+After a scan, three files are written in the current directory:
+
+- `emails.txt` – each line contains an email and the URL where it was first
+  seen separated by a tab.
+- `phones.txt` – phone numbers paired with their source URL, also tab
+  separated.
+- `breached_emails.txt` – emails that were found in breaches.
+
+Debug logs record every discovery including a short snippet of the surrounding
+text.
 

--- a/breach_checker.py
+++ b/breach_checker.py
@@ -29,6 +29,7 @@ import re
 import sys
 import json
 import asyncio
+import logging
 from urllib.parse import urljoin, urlparse
 from collections import deque
 import phonenumbers
@@ -39,6 +40,18 @@ import subprocess
 from typing import Set, List, Optional
 import aiohttp
 from playwright.async_api import async_playwright
+
+LOG_FILE = os.environ.get("BREACH_LOG_FILE", "breach_checker.log")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler(),
+    ],
+)
+
+logger = logging.getLogger(__name__)
 
 
 # Standard library modules provide URL handling and queues while
@@ -59,9 +72,10 @@ def load_config() -> dict:
             data = json.load(f)
             if isinstance(data, dict):
                 config.update({k: v for k, v in data.items() if v})
-    except Exception:
+            logger.debug("Loaded configuration from config.json")
+    except Exception as exc:
         # Missing or invalid config is silently ignored
-        pass
+        logger.debug("Could not load config.json: %s", exc)
     return config
 
 
@@ -71,6 +85,7 @@ def enumerate_subdomains(domain: str) -> Set[str]:
     Wildcard entries like ``*.example.com`` are stripped of the ``*`` to avoid
     invalid hostnames being crawled.
     """
+    logger.info("Enumerating subdomains for %s", domain)
     subs = set()
     # Try the "subfinder" tool first as it is fast and comprehensive
     if shutil.which("subfinder"):
@@ -83,9 +98,10 @@ def enumerate_subdomains(domain: str) -> Set[str]:
             ], capture_output=True, text=True, check=False, timeout=60)
             subs.update(line.strip()
                         for line in result.stdout.splitlines() if line.strip())
-        except Exception:
+            logger.debug("subfinder returned %d results", len(subs))
+        except Exception as exc:
             # Ignore failures and fall back to web-based enumeration
-            pass
+            logger.debug("subfinder failed: %s", exc)
     # Fallback to crt.sh if none found
     if not subs:
         try:
@@ -101,11 +117,12 @@ def enumerate_subdomains(domain: str) -> Set[str]:
                             sub = sub.lstrip('*.')
                         if sub and sub.endswith(domain):
                             subs.add(sub)
-        except Exception:
+        except Exception as exc:
             # Any network/JSON error simply results in returning the main domain
-            pass
+            logger.debug("crt.sh lookup failed: %s", exc)
     # Always include main domain
     subs.add(domain)
+    logger.info("Found %d subdomains", len(subs))
     return subs
 
 
@@ -116,9 +133,12 @@ def choose_scheme(host: str) -> str:
             resp = requests.head(f"{scheme}://{host}",
                                  timeout=5, allow_redirects=True)
             if resp.status_code < 400:
+                logger.debug("%s is reachable via %s", host, scheme)
                 return scheme
-        except Exception:
+        except Exception as exc:
+            logger.debug("Error checking %s via %s: %s", host, scheme, exc)
             continue
+    logger.debug("Defaulting to http for %s", host)
     return "http"
 
 
@@ -132,6 +152,7 @@ def gather_with_katana(start_url: str, depth: int, field_file: str):
     phones: Set[str] = set()
 
     try:
+        logger.info("Running katana against %s", start_url)
         result = subprocess.run(
             [
                 "katana",
@@ -156,8 +177,10 @@ def gather_with_katana(start_url: str, depth: int, field_file: str):
             emails.add(email.strip())
         for phone in PHONE_RE.findall(output):
             phones.add(phone.strip())
-    except Exception:
-        pass
+        logger.debug("katana found %d urls, %d emails, %d phones",
+                     len(urls), len(emails), len(phones))
+    except Exception as exc:
+        logger.warning("katana execution failed: %s", exc)
 
     return urls, emails, phones
 
@@ -165,6 +188,7 @@ def gather_with_katana(start_url: str, depth: int, field_file: str):
 async def fetch_url(session, url: str) -> Optional[str]:
     """Fetch a URL using Playwright (for JavaScript-rendered content)."""
     try:
+        logger.debug("Fetching %s", url)
         async with async_playwright() as p:
             browser = await p.chromium.launch(headless=True)
             page = await browser.new_page()
@@ -173,7 +197,7 @@ async def fetch_url(session, url: str) -> Optional[str]:
             await browser.close()
             return content
     except Exception as e:
-        print(f"[💥] Playwright error at {url}: {e}")
+        logger.warning("Playwright error at %s: %s", url, e)
         return None
 
 
@@ -246,21 +270,30 @@ class Crawler:
         # Containers for discovered data (canonical -> original)
         self.emails: dict[str, str] = {}
         self.phones: dict[str, str] = {}
+        # Maps for the first seen location of each item
+        self.email_sources: dict[str, str] = {}
+        self.phone_sources: dict[str, str] = {}
 
-    def add_email(self, email: str) -> None:
+    def add_email(self, email: str, source: str, snippet: str = "") -> None:
         """Store email if not already seen (case-insensitive)."""
         canon = normalize_email(email)
         if canon not in self.emails:
             self.emails[canon] = email.strip()
+            self.email_sources[canon] = source
+        logger.debug("Email %s found at %s | %s", email, source, snippet)
 
-    def add_phone(self, phone: str) -> None:
+    def add_phone(self, phone: str, source: str, snippet: str = "") -> None:
         """Store phone in normalized form if valid and not already seen."""
         norm = normalize_phone(phone)
-        if norm and norm not in self.phones:
-            self.phones[norm] = norm
+        if norm:
+            if norm not in self.phones:
+                self.phones[norm] = norm
+                self.phone_sources[norm] = source
+            logger.debug("Phone %s found at %s | %s", norm, source, snippet)
 
     async def crawl(self, start_url: str):
         """Breadth-first crawl starting from the supplied URL."""
+        logger.info("Starting crawl at %s", start_url)
         queue = deque([(start_url, 0)])
         async with aiohttp.ClientSession() as session:
             while queue:
@@ -270,30 +303,34 @@ class Crawler:
                     if depth > self.max_depth or url in self.visited:
                         continue
                     self.visited.add(url)
+                    logger.debug("Queueing %s (depth %d)", url, depth)
                     tasks.append(self._process_url(session, url, depth, queue))
                 if tasks:
                     await asyncio.gather(*tasks)
 
     async def _process_url(self, session: aiohttp.ClientSession, url: str, depth: int, queue: deque):
+        logger.info("Crawling %s", url)
+        logger.debug("Processing %s", url)
         content = await fetch_url(session, url)
         if not content:
             return
-        self.extract_data(content)
+        self.extract_data(content, url)
         soup = BeautifulSoup(content, "html.parser")
         # also search the rendered text for emails split by HTML tags
-        self.extract_data(soup.get_text(" "))
+        self.extract_data(soup.get_text(" "), url)
         # capture mailto: links explicitly (case-insensitive)
         for a in soup.find_all("a", href=True):
             href = a["href"]
             if href.lower().startswith("mailto:"):
                 addr = href.split(":", 1)[1].split("?", 1)[0]
-                self.add_email(addr)
+                self.add_email(addr, url, "mailto link")
         for link in soup.find_all("a", href=True):
             new_url = urljoin(url, link["href"])
             parsed = urlparse(new_url)
             if parsed.scheme.startswith("http") and parsed.netloc.endswith(self.domain):
                 if new_url not in self.visited:
                     queue.append((new_url, depth + 1))
+                    logger.debug("Discovered link %s", new_url)
         # also crawl JS sources so we don't miss inline references
         for script in soup.find_all("script", src=True):
             src = urljoin(url, script["src"])
@@ -301,13 +338,22 @@ class Crawler:
             if parsed.scheme.startswith("http") and parsed.netloc.endswith(self.domain):
                 if src not in self.visited:
                     queue.append((src, depth + 1))
+                    logger.debug("Discovered script %s", src)
 
-    def extract_data(self, text: str):
+    def extract_data(self, text: str, url: str):
         """Pull data of interest out of page text."""
-        for email in EMAIL_RE.findall(text):
-            self.add_email(email)
-        for phone in PHONE_RE.findall(text):
-            self.add_phone(phone)
+        email_matches = list(EMAIL_RE.finditer(text))
+        phone_matches = list(PHONE_RE.finditer(text))
+        for m in email_matches:
+            snippet = text[max(m.start()-20, 0): m.end()+20].replace("\n", " ")
+            self.add_email(m.group(), url, snippet)
+        for m in phone_matches:
+            snippet = text[max(m.start()-20, 0): m.end()+20].replace("\n", " ")
+            self.add_phone(m.group(), url, snippet)
+        if email_matches or phone_matches:
+            logger.debug(
+                "Extracted %d emails and %d phones", len(email_matches), len(phone_matches)
+            )
 
 
 # ---------------------- Breach checkers ----------------------
@@ -322,15 +368,19 @@ def check_hibp(email: str, api_key: Optional[str]) -> Optional[List[str]]:
         "user-agent": "DomainCrawler/1.0",
     }
     try:
+        logger.debug("Checking HIBP for %s", email)
         resp = requests.get(
             url, headers=headers, params={"truncateResponse": "false"}, timeout=10
         )
         if resp.status_code == 200:
-            return [b.get("Name") for b in resp.json()]
+            breaches = [b.get("Name") for b in resp.json()]
+            logger.debug("%s found in %d breaches", email, len(breaches))
+            return breaches
         if resp.status_code == 404:
+            logger.debug("%s not found in HIBP", email)
             return []
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("HIBP lookup failed for %s: %s", email, exc)
     return None
 
 # ---------------------- High level scan function ----------------------
@@ -345,6 +395,7 @@ async def scan_domain(domain: str, depth: int = 3, hibp_key: Optional[str] = Non
     """
     if verbose:
         print(f"Enumerating subdomains for {domain}...")
+    logger.info("Scanning domain %s at depth %d", domain, depth)
     subdomains = enumerate_subdomains(domain)
     if verbose:
         for sub in sorted(subdomains):
@@ -355,6 +406,10 @@ async def scan_domain(domain: str, depth: int = 3, hibp_key: Optional[str] = Non
 
     if use_katana and verbose:
         print("Using katana for deep enumeration")
+    if use_katana:
+        logger.info("katana available; using for enumeration")
+    else:
+        logger.info("katana not available; using internal crawler only")
 
     crawler = Crawler(domain, max_depth=0 if use_katana else depth)
 
@@ -363,13 +418,14 @@ async def scan_domain(domain: str, depth: int = 3, hibp_key: Optional[str] = Non
         start_url = f"{scheme}://{sub}"
         if verbose:
             print(f"\nCrawling {start_url} ...")
+        logger.info("Crawling %s", start_url)
         if use_katana:
             urls, emails, phones = gather_with_katana(
                 start_url, depth, field_file)
             for e in emails:
-                crawler.add_email(e)
+                crawler.add_email(e, start_url, "katana")
             for p in phones:
-                crawler.add_phone(p)
+                crawler.add_phone(p, start_url, "katana")
             if not urls:
                 urls = {start_url}
             for link in urls:
@@ -384,12 +440,16 @@ async def scan_domain(domain: str, depth: int = 3, hibp_key: Optional[str] = Non
             breached_emails[email] = breaches
 
     # Expose the collected data directly for easier consumption by callers.
+    logger.info("Scan complete: %d emails, %d phones, %d breached emails",
+                len(crawler.emails), len(crawler.phones), len(breached_emails))
     return {
         "crawler": crawler,
         "subdomains": subdomains,
         "emails": set(crawler.emails.values()),
         "phones": set(crawler.phones.values()),
         "breached_emails": breached_emails,
+        "email_sources": crawler.email_sources,
+        "phone_sources": crawler.phone_sources,
     }
 
 
@@ -407,22 +467,31 @@ async def main():
     cfg = load_config()
     depth = int(os.environ.get("CRAWL_DEPTH", cfg.get("crawl_depth", 3)))
     hibp_key = os.environ.get("HIBP_API_KEY") or cfg.get("hibp_api_key")
+    logger.debug("Using crawl depth %d", depth)
 
     results = await scan_domain(domain, depth, hibp_key, verbose=True)
     subdomains = results["subdomains"]
     emails = results["emails"]
     phones = results["phones"]
     breached_emails = results["breached_emails"]
+    crawler = results["crawler"]
     # ---- write results to files ----
+
+    def save_map(filename: str, values: dict[str, str], sources: dict[str, str]):
+        with open(filename, "w", encoding="utf-8") as f:
+            for canon, value in sorted(values.items()):
+                src = sources.get(canon, "")
+                f.write(f"{value}\t{src}\n")
 
     def save_set(filename: str, data: Set[str]):
         with open(filename, "w", encoding="utf-8") as f:
             for item in sorted(data):
                 f.write(item + "\n")
 
-    save_set("emails.txt", emails)
-    save_set("phones.txt", phones)
+    save_map("emails.txt", crawler.emails, crawler.email_sources)
+    save_map("phones.txt", crawler.phones, crawler.phone_sources)
     save_set("breached_emails.txt", set(breached_emails.keys()))
+    logger.info("Results written to output files")
 
     # ---- print summary to console ----
     print("\n--------- Summary ---------")
@@ -436,6 +505,7 @@ async def main():
             print(f" - {email}: {', '.join(breaches)}")
 
     print("\nResults saved to emails.txt, breached_emails.txt, phones.txt")
+    logger.info("Summary: %d emails, %d phones, %d breached", len(emails), len(phones), len(breached_emails))
 
     # ---- return results so callers can use them ----
     return results

--- a/breakservice/api/views.py
+++ b/breakservice/api/views.py
@@ -20,10 +20,15 @@ class ScanView(APIView):
             depth = int(request.data.get(
                 "depth", os.environ.get("CRAWL_DEPTH", 3)))
             hibp_key = os.environ.get("HIBP_API_KEY")
-            logging.warning(
+            logging.info(
                 "SCAN: Starting scan for %s (depth=%s)", domain, depth)
             results = async_to_sync(scan_domain)(domain, depth, hibp_key)
-            logging.warning("SCAN: Scan completed for %s", domain)
+            logging.info("SCAN: Scan completed for %s", domain)
+            logging.info(
+                "SCAN: emails=%d phones=%d breached=%d", 
+                len(results["emails"]),
+                len(results["phones"]),
+                len(results["breached_emails"]))
         except Exception as e:
             logging.exception("SCAN: Exception in scan_domain")
             return Response({"error": str(e)}, status=500)
@@ -39,5 +44,7 @@ class ScanView(APIView):
             "emails":          sorted(results["emails"]),
             "phones":          sorted(results["phones"]),
             "breached_emails": results["breached_emails"],
+            "email_sources":   results["email_sources"],
+            "phone_sources":   results["phone_sources"],
         }
         return Response(payload)


### PR DESCRIPTION
## Summary
- store URL source for each discovered email and phone
- log where each email and phone was found
- include source info in CLI output files and API responses
- document output file format in README

## Testing
- `python -m py_compile breach_checker.py breakservice/api/views.py`
- `pip install -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_687d12a0831c8324a45649ccc4a149a0