### PR TITLE
Improve logging and result saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ The API will be available on `http://localhost:8000/`.
 
 ## Output files
 
-After a scan, three files are written in the current directory:
+After a scan, several files are written in the current directory:
 
-- `emails.txt` – each line contains an email and the URL where it was first
-  seen separated by a tab.
-- `phones.txt` – phone numbers paired with their source URL, also tab
-  separated.
+- `emails.txt` – list of discovered email addresses.
+- `email_sources.txt` – email addresses paired with the URL where they were first seen.
+- `phones.txt` – normalized phone numbers.
+- `phone_sources.txt` – phone numbers with their source URL.
 - `breached_emails.txt` – emails that were found in breaches.
 
 Debug logs record every discovery including a short snippet of the surrounding

--- a/breakservice/api/views.py
+++ b/breakservice/api/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from asgiref.sync import async_to_sync
 import os
-from breach_checker import scan_domain
+from breach_checker import scan_domain, save_results
 
 import logging
 
@@ -23,9 +23,10 @@ class ScanView(APIView):
             logging.info(
                 "SCAN: Starting scan for %s (depth=%s)", domain, depth)
             results = async_to_sync(scan_domain)(domain, depth, hibp_key)
+            save_results(results)
             logging.info("SCAN: Scan completed for %s", domain)
             logging.info(
-                "SCAN: emails=%d phones=%d breached=%d", 
+                "SCAN: emails=%d phones=%d breached=%d",
                 len(results["emails"]),
                 len(results["phones"]),
                 len(results["breached_emails"]))


### PR DESCRIPTION
## Summary
- rotate log file and configure handlers once
- stream katana output to log
- centralize saving results to disk
- call save_results from API and CLI
- document new output files in README

## Testing
- `python3 -m py_compile breach_checker.py breakservice/api/views.py`

------
https://chatgpt.com/codex/tasks/task_e_687d2f52173083249f6823957e148eba