### PR TITLE
Improve logging and automatic result saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Two environment variables configure the crawler:
 
 - `HIBP_API_KEY` – HaveIBeenPwned API key.
 - `CRAWL_DEPTH` – maximum crawl depth (defaults to `3`).
-- `BREACH_LOG_FILE` – optional path to the log file (defaults to
+- `BREACH_LOG_FILE` – optional path to the rotating log file (defaults to
   `breach_checker.log`).
 
 When a `config.json` file exists in the repository root it overrides the
@@ -38,8 +38,10 @@ export HIBP_API_KEY=YOUR_HIBP_KEY
 # optional: export BREACH_LOG_FILE=/path/to/scan.log
 python breach_checker.py
 ```
-Follow the prompts to scan a domain and save results locally. The configuration
-can also be provided in `config.json` as shown above.
+Follow the prompts to scan a domain. Results are automatically written to
+`emails.txt`, `phones.txt`, `email_sources.txt`, `phone_sources.txt` and
+`breached_emails.txt`. The configuration can also be provided in `config.json`
+as shown above.
 
 ## Running the API server
 

--- a/breakservice/api/views.py
+++ b/breakservice/api/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from asgiref.sync import async_to_sync
 import os
-from breach_checker import scan_domain, save_results
+from breach_checker import scan_domain
 
 import logging
 
@@ -23,7 +23,6 @@ class ScanView(APIView):
             logging.info(
                 "SCAN: Starting scan for %s (depth=%s)", domain, depth)
             results = async_to_sync(scan_domain)(domain, depth, hibp_key)
-            save_results(results)
             logging.info("SCAN: Scan completed for %s", domain)
             logging.info(
                 "SCAN: emails=%d phones=%d breached=%d",

--- a/field-config.yaml
+++ b/field-config.yaml
@@ -1,7 +1,7 @@
 - name: email
   type: regex
   regex:
-    - '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(?!(?:png|jpg|jpeg|gif|svg|bmp|webp|ico|css|js|json|xml|csv|txt|pdf|doc|docx|xls|xlsx)\b)[a-zA-Z]{2,}'
+    - '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
 
 - name: phone
   type: regex


### PR DESCRIPTION
## Summary
- configure rotating file logging for reuse across CLI and API
- log katana progress per discovered URL
- log each email and phone and all fetch requests
- save output files within `scan_domain`
- simplify katana email regex for Go compatibility
- update docs about rotating log file and automatic result writing

## Testing
- `python -m py_compile breach_checker.py`
- `python -m py_compile breakservice/api/views.py`

------
https://chatgpt.com/codex/tasks/task_e_687d3801ef608324b82a6afc1ba88d59