### PR TITLE
Add CLI argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ environment variables. The file should contain:
 ```bash
 export HIBP_API_KEY=YOUR_HIBP_KEY
 # optional: export CRAWL_DEPTH=2
-python break_checker.py example.com --depth 2
+python break_checker.py example.com --depth 2 --json
 ```
-Run the script with the target domain as an argument. Configuration can also be
-provided in `config.json` as shown above.
+Run the script with the target domain as an argument. Add `--json` to write a
+`results.json` file and `--verbose` to display detailed log output.
+Configuration can also be provided in `config.json` as shown above.
 
 ## Running the API server
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ environment variables. The file should contain:
 ```bash
 export HIBP_API_KEY=YOUR_HIBP_KEY
 # optional: export CRAWL_DEPTH=2
-python breach_checker.py
+python break_checker.py example.com --depth 2
 ```
-Follow the prompts to scan a domain and save results locally. The configuration
-can also be provided in `config.json` as shown above.
+Run the script with the target domain as an argument. Configuration can also be
+provided in `config.json` as shown above.
 
 ## Running the API server
 


### PR DESCRIPTION
## Summary
- switch CLI script to use `argparse`
- allow command line arguments for domain, depth, API key, and verbose
- update README with new usage instructions

## Testing
- `python -m py_compile break_checker.py breakservice/api/views.py`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68878bda17a08324ab5f817331b5ec52