### PR TITLE
Add domain validation into break_checker

### DIFF
--- a/breakservice/api/views.py
+++ b/breakservice/api/views.py
@@ -3,19 +3,23 @@ from rest_framework.response import Response
 from rest_framework import status
 from asgiref.sync import async_to_sync
 import os
-from break_checker import scan_domain, load_config
+from break_checker import scan_domain, load_config, validate_domain
 
 import logging
 
 
 class ScanView(APIView):
     def post(self, request):
-        domain = request.data.get("domain")
-        if not domain:
+        domain_raw = request.data.get("domain")
+        if not domain_raw:
             return Response(
                 {"error": "domain parameter required"},
                 status=status.HTTP_400_BAD_REQUEST
             )
+
+        valid, domain, msg = validate_domain(domain_raw, check_dns=False)
+        if not valid:
+            return Response({"error": msg}, status=status.HTTP_400_BAD_REQUEST)
         try:
             cfg = load_config()
             depth = int(request.data.get(
@@ -25,8 +29,13 @@ class ScanView(APIView):
             logging.info(
                 "SCAN: Starting scan for %s (depth=%s)", domain, depth)
             results = async_to_sync(scan_domain)(domain, depth, hibp_key)
-            logging.info("SCAN: Scan completed for %s with %d breached emails of %d emails and %d phones", domain, len(
-                results["breached_emails"]), len(results["emails"]), len(results["phones"]))
+            logging.info(
+                "SCAN: Scan completed for %s with %d breached emails of %d emails and %d phones",
+                domain,
+                len(results["breached_emails"]),
+                len(results["emails"]),
+                len(results["phones"]),
+            )
         except Exception as e:
             logging.exception("SCAN: Exception in scan_domain")
             return Response({"error": str(e)}, status=500)


### PR DESCRIPTION
## Summary
- inline `validate_domain` helper directly in `break_checker.py`
- remove obsolete `domain_utils.py`
- update API view to import the helper from `break_checker`

## Testing
- `python -m py_compile break_checker.py breakservice/api/views.py`
- `python - <<'PY'
import re, socket
from urllib.parse import urlparse

def validate_domain(user_input: str, *, check_dns: bool = False):
    if not user_input or not user_input.strip():
        return False, "", "No domain provided"
    raw = user_input.strip()
    parsed = urlparse(raw if "//" in raw else f"//{raw}")
    host = parsed.netloc or parsed.path
    if host.lower().startswith("www."):
        host = host[4:]
    if ':' in host:
        host = host.split(':', 1)[0]
    host = host.strip('.').lower()
    if not host:
        return False, '', 'No domain provided'
    try:
        host_ascii = host.encode('idna').decode('ascii')
    except Exception:
        return False, '', 'Invalid internationalized domain'
    if len(host_ascii) > 253:
        return False, '', 'Domain exceeds maximum length'
    labels = host_ascii.split('.')
    if len(labels) < 2 or len(labels[-1]) < 2:
        return False, '', 'Domain must include a valid TLD'
    label_re = re.compile(r"^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)$")
    for label in labels:
        if len(label) == 0 or len(label) > 63:
            return False, '', 'Domain label length invalid'
        if not label_re.fullmatch(label):
            return False, '', 'Invalid domain format'
    if check_dns:
        try:
            socket.gethostbyname(host_ascii)
            return True, host_ascii, 'Valid and resolvable'
        except Exception:
            return True, host_ascii, 'Valid but not resolvable'
    return True, host_ascii, 'Valid'

cases = ['example.com','https://www.Example.com/path','bücher.de','δοκιμή.gr','invalid_domain','ex@mple.com']
for c in cases:
    print(c, '->', validate_domain(c))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68890dc41b1083248b2c176199a50628