### PR TITLE
Improve verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,10 @@ docker-compose up --build
 
 The API will be available on `http://localhost:8000/`.
 
+## Logging
+
+Run the CLI with `-v` or `--verbose` to enable debug logging. In verbose mode
+the crawler prints the depth of each URL as it is processed and shows a snippet
+around any discovered email or phone number. Without `-v` these snippets are
+omitted for cleaner output.
+


### PR DESCRIPTION
## Summary
- log email/phone snippets only when debug logging is enabled
- show crawl depth and extraction messages in verbose mode
- display scan duration and final summary
- document new logging behaviour

## Testing
- `python -m py_compile break_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_688be7ec0f408324a414a06814068c45