### PR TITLE
Remove Katana integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,6 @@ RUN apt-get update && \
     libxext6 libxi6 libxcb1 libx11-6 libdrm2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Katana (v1.2.1, Linux amd64)
-RUN wget -q https://github.com/projectdiscovery/katana/releases/download/v1.2.1/katana_1.2.1_linux_amd64.zip \
-    && unzip katana_1.2.1_linux_amd64.zip \
-    && mv katana /usr/local/bin/katana \
-    && chmod +x /usr/local/bin/katana \
-    && rm katana_1.2.1_linux_amd64.zip
-
 # Install Subfinder (v2.8.0, Linux amd64)
 RUN wget -q https://github.com/projectdiscovery/subfinder/releases/download/v2.8.0/subfinder_2.8.0_linux_amd64.zip \
     && unzip subfinder_2.8.0_linux_amd64.zip \

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ The scanner runs in several distinct stages:
    to free services like crt.sh, HackerTarget and Anubis DB.
 2. **Check accessibility** – each discovered subdomain is probed for HTTP/HTTPS
    support so only reachable hosts are crawled.
-3. **Crawl the site** – if the `katana` crawler is installed it is used for
-   deeper enumeration, otherwise an internal asynchronous crawler collects pages
-   with Playwright. Links and scripts are followed up to the configured depth.
+3. **Crawl the site** – an internal asynchronous crawler collects pages with
+   Playwright. Links and scripts are followed up to the configured depth.
 4. **Extract contacts** – emails and phone numbers are validated, normalized and
    stored together with the page on which they were seen.
 5. **Breach lookups** – emails are checked via a HaveIBeenPwned proxy API and
@@ -32,9 +31,9 @@ Install the pinned Python requirements:
 pip install -r requirements.txt
 ```
 
-Some stages optionally use external tools (``subfinder`` and ``katana``). They
-are installed automatically in the provided Docker image, but you can also
-install them manually for the CLI.
+Some stages optionally use the external tool ``subfinder``. It is installed
+automatically in the provided Docker image, but you can also install it manually
+for the CLI.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- drop Katana from the Docker image and docs
- rely solely on the internal Python crawler during scans

## Testing
- `python -m py_compile break_checker.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a9fe24848324b297def3b8531da8