### PR TITLE
Add email scope filtering options to BreakChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Each argument configures how the scan is performed:
 - `--csv` – save results to `DOMAIN-TIMESTAMP.csv`
 - `--md`, `--report` – save results to `DOMAIN-TIMESTAMP.md`
 - `-o`, `--output` – optional custom path for the report file
+- `--email-scope` – filter collected emails: `host` (target domain and subdomains),
+  `org` (registered domain, default) or `any` (no filtering)
 
 Logs are written to `break_checker.log` in the working directory and printed on
 the console. Set the `BREACH_LOG_FILE` environment variable to change the log

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ gunicorn~=23.0.0
 phonenumbers~=9.0.10
 playwright~=1.54.0
 email-validator~=2.1
+tldextract~=5.1
+


### PR DESCRIPTION
## Summary
- Add `--email-scope` CLI option with host/org/any modes (default org)
- Filter collected emails based on scope using string checks or tldextract
- Track kept vs dropped email counts and log filtering decisions
- Document email scope option and include tldextract dependency

## Testing
- `python -m py_compile break_checker.py`
- `python break_checker.py --help`
- `python break_checker.py example.com --depth 0 --concurrency 1 --email-scope host`

------
https://chatgpt.com/codex/tasks/task_e_689a9a6c4968832494832cb44b173cb8