### PR TITLE
Track endpoints and invalid contacts with scan timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,15 @@ Example response:
 ```json
 {
   "domain": "example.com",
+  "scan_start": "2024-01-01 12:00:00",
+  "scan_end": "2024-01-01 12:00:10",
   "summary": {
+    "num_endpoints": 42,
     "num_subdomains": 3,
     "num_emails": 2,
+    "num_invalid_emails": 1,
     "num_phones": 1,
+    "num_invalid_phones": 0,
     "num_breached_emails": 1,
     "num_breached_phones": 1
   },

--- a/breakservice/api/views.py
+++ b/breakservice/api/views.py
@@ -34,12 +34,15 @@ class ScanView(APIView):
                 domain, depth, hibp_key, leak_key)
 
             logging.info(
-                "SCAN: Scan completed with %d subdomains, %d emails (%d breached), and %d phones (%d breached).",
+                "SCAN: Scan completed with %d endpoints, %d subdomains, %d emails (%d breached, %d dropped), and %d phones (%d breached, %d dropped).",
+                results.get("num_endpoints", 0),
                 len(results["subdomains"]),
                 len(results["emails"]),
                 len(results["breached_emails"]),
+                results.get("emails_dropped", 0),
                 len(results["phones"]),
                 len(results.get("breached_phones", {})),
+                results.get("phones_dropped", 0),
             )
         except Exception as e:
             logging.exception("SCAN: Exception in scan_domain")
@@ -47,10 +50,15 @@ class ScanView(APIView):
 
         payload = {
             "domain": domain,
+            "scan_start": results.get("scan_start"),
+            "scan_end": results.get("scan_end"),
             "summary": {
+                "num_endpoints": results.get("num_endpoints", 0),
                 "num_subdomains": len(results["subdomains"]),
                 "num_emails": len(results["emails"]),
+                "num_invalid_emails": results.get("emails_dropped", 0),
                 "num_phones": len(results["phones"]),
+                "num_invalid_phones": results.get("phones_dropped", 0),
                 "num_breached_emails": len(results["breached_emails"]),
                 "num_breached_phones": len(results.get("breached_phones", {})),
             },


### PR DESCRIPTION
## Summary
- count crawled endpoints and dropped emails/phones
- record scan start and end times in log-style `%Y-%m-%d %H:%M:%S` format for saved reports and API responses
- expose new statistics and timestamps in CLI summaries and README example

## Testing
- `python -m py_compile break_checker.py breakservice/api/views.py`


------
https://chatgpt.com/codex/tasks/task_e_689c914edb088324b2934404d22a6b0d